### PR TITLE
More command line

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -191,6 +191,12 @@ class DockerBenchmarkRunner(BenchmarkRunner):
             with open(messages_path) as f:
                 messages = json.load(f)
                 return messages
+
+
+runners = {
+    "docker": DockerBenchmarkRunner(),
+    "host": DefaultBenchmarkRunner(),
+}
     
 
 def run_benchmark(benchmark: TasksStore, mod: TaskSetModifier, command: OpenInterpreterCommand) -> List[TaskResult]:

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -56,13 +56,13 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-l", "--list", action="store_true", help="list the possible command configuration ids")
-    parser.add_argument("-c", "--command", action="store", type=str, default=default_command_id, help=f"change the command configuration ({", ".join(commands.keys())})")
+    parser.add_argument("-c", "--command", action="store", type=str, default=default_command_id, help=f"change the command configuration ({', '.join(commands.keys())})")
     parser.add_argument("-nt", "--ntasks", action="store", type=int, help="run the first n tasks for the selected benchmark")
     parser.add_argument("-nw", "--nworkers", action="store", type=int, help="run the benchmarks across n workers (docker containers, processes, E2B instances, etc.)")
     parser.add_argument("-to", "--task-offset", action="store", type=int, default=0)
     parser.add_argument("-s", "--server", action="store_true", help="launch a server that keeps track of and displays task starts, stops, and logging")
-    parser.add_argument("-r", "--runner", action="store", type=str, default=default_runner, help=f"the kind of worker to run each task on ({", ".join(runners.keys())})")
-    parser.add_argument("-b", "--benchmark", action="store", default=default_benchmark, help=f"where to retreive the list of tasks to run from ({", ".join(task_stores.keys())})")
+    parser.add_argument("-r", "--runner", action="store", type=str, default=default_runner, help=f"the kind of worker to run each task on ({', '.join(runners.keys())})")
+    parser.add_argument("-b", "--benchmark", action="store", default=default_benchmark, help=f"where to retreive the list of tasks to run from ({', '.join(task_stores.keys())})")
     parser.add_argument("-bf", "--bfile", action="store", type=str, help="only works when '--benchmark custom' is used")
     args = parser.parse_args(namespace=ArgumentsNamespace())
 

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 from constants import DATASETS
 from custom import CustomTasks
-from benchmark import DefaultBenchmarkRunner, DockerBenchmarkRunner, ModifierPipe, OIBenchmarks, SizeOffsetModifier, TaskResult
+from benchmark import DefaultBenchmarkRunner, DockerBenchmarkRunner, ModifierPipe, OIBenchmarks, SizeOffsetModifier, TaskResult, runners
 from commands import commands
 from gaia import GAIAFilesOnlyModifier, GAIATasks
 
@@ -38,19 +38,32 @@ class ArgumentsNamespace(argparse.Namespace):
     task_offset: int
     nworkers: Optional[int]
     server: bool
+    runner: str
+    benchmark: str
+    bfile: Optional[str]
+
+
+task_stores = {
+    "gaia": GAIATasks()
+}
 
 
 if __name__ == "__main__":
     default_command_id = ""
     default_output_file_dir = Path(".local/results")
+    default_runner = "docker"
+    default_benchmark = "gaia"
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-l", "--list", action="store_true")
-    parser.add_argument("-c", "--command", action="store", type=str, default=default_command_id)
-    parser.add_argument("-nt", "--ntasks", action="store", type=int)
-    parser.add_argument("-nw", "--nworkers", action="store", type=int)
+    parser.add_argument("-l", "--list", action="store_true", help="list the possible command configuration ids")
+    parser.add_argument("-c", "--command", action="store", type=str, default=default_command_id, help=f"change the command configuration ({", ".join(commands.keys())})")
+    parser.add_argument("-nt", "--ntasks", action="store", type=int, help="run the first n tasks for the selected benchmark")
+    parser.add_argument("-nw", "--nworkers", action="store", type=int, help="run the benchmarks across n workers (docker containers, processes, E2B instances, etc.)")
     parser.add_argument("-to", "--task-offset", action="store", type=int, default=0)
-    parser.add_argument("-s", "--server", action="store_true")
+    parser.add_argument("-s", "--server", action="store_true", help="launch a server that keeps track of and displays task starts, stops, and logging")
+    parser.add_argument("-r", "--runner", action="store", type=str, default=default_runner, help=f"the kind of worker to run each task on ({", ".join(runners.keys())})")
+    parser.add_argument("-b", "--benchmark", action="store", default=default_benchmark, help=f"where to retreive the list of tasks to run from ({", ".join(task_stores.keys())})")
+    parser.add_argument("-bf", "--bfile", action="store", type=str, help="only works when '--benchmark custom' is used")
     args = parser.parse_args(namespace=ArgumentsNamespace())
 
     if args.list:
@@ -58,7 +71,21 @@ if __name__ == "__main__":
         exit(0)
     if args.command not in commands:
         print(f"'{args.command}' not recognized as a command configuration id")
+        print("possible command configuration ids:", list(commands.keys()))
         exit(1)
+    if args.runner not in runners:
+        print(f"'{args.runner}' not recognized as a runner id")
+        print("possible runner ids:", list(runners.keys()))
+        exit(1)
+    if args.benchmark not in task_stores and args.benchmark != "custom":
+        print(f"'{args.benchmark}' not recognized as a benchmark id")
+        print("possible benchmark ids:", [*task_stores.keys(), "custom"])
+        exit(1)
+    if args.benchmark == "custom" and args.bfile is None:
+        print(f"'--benchmark custom' can only be used if '--bflag <file-path>' is also used.")
+        exit(1)
+    tasks = task_stores[args.benchmark] if args.benchmark in task_stores else CustomTasks.from_csv(args.bfile)  # type: ignore
+    runner = runners[args.runner]
     
     print("command configuration:", args.command)
     now_utc = datetime.now(timezone.utc)
@@ -66,20 +93,11 @@ if __name__ == "__main__":
     print("output file:", save_path)
 
     results = OIBenchmarks(
-        # tasks=CustomTasks.from_list([
-        #     {"id": "simple", "prompt": "what is 3 + 4?", "answer": "7"},
-        #     {"id": "hard", "prompt": "who do you think you are??", "answer": "laptop"},
-        # ]),
-        tasks=GAIATasks(),
-        modifier=ModifierPipe([
-            # GAIAFilesOnlyModifier(),
-            SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset)
-        ]),
-        # modifier=SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset),
+        tasks=tasks,
+        modifier=SizeOffsetModifier(ntasks=args.ntasks, offset=args.task_offset),
         command=commands[args.command],
         nworkers=args.nworkers,
-        # runner=DefaultBenchmarkRunner()
-        runner=DockerBenchmarkRunner(),
+        runner=runner,
         server=args.server
     ).run()
 


### PR DESCRIPTION
- Added command line options to get the command line functionality closer in-line with the OIBenchmarks functionality.
- Wrote descriptions for most of the command line options.

The following options can now be configured from the command line:
- The platform the workers run on (e.g. docker, host computer), and
- the kind of benchmark to run (GAIA or custom).

More work needs to be done to document the format of the benchmark file, but the base functionality is there.